### PR TITLE
Fix bulk upload by correctly handling empty database case

### DIFF
--- a/app_pages/data_points.py
+++ b/app_pages/data_points.py
@@ -59,8 +59,11 @@ def data_points_page():
                 else:
                     st.success("File validation successful! Processing records...")
                     # Get existing data point names for update/add logic
-                    existing_points_df, _ = get_all_data_points()
-                    existing_names = [row['name'] for row in existing_points_df]
+                    existing_points, columns = get_all_data_points()
+                    existing_points_df = pd.DataFrame(existing_points, columns=columns)
+                    existing_names = []
+                    if not existing_points_df.empty:
+                        existing_names = existing_points_df['name'].tolist()
 
                     for i, row in validated_df.iterrows():
                         name = row['name']


### PR DESCRIPTION
The previous code did not correctly handle the case where the `data_points` table was empty. This caused an error during the bulk upload process when trying to get the names of existing data points.

This commit fixes the issue by explicitly creating a pandas DataFrame from the result of `get_all_data_points` and handling the case where the DataFrame is empty.