### PR TITLE
Add Streamlit config to fix 403 error on bulk upload

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[server]
+enableXsrfProtection = false
+enableCORS = false


### PR DESCRIPTION
This commit adds a `.streamlit/config.toml` file to disable CSRF (Cross-Site Request Forgery) and CORS protection.

This is to fix a 403 Forbidden error that occurs during file uploads in some environments.